### PR TITLE
LoganSquareConverterFactory can only be added at the end

### DIFF
--- a/converter-logansquare/src/main/java/de/mannodermaus/retrofit2/LoganSquareConverterFactory.java
+++ b/converter-logansquare/src/main/java/de/mannodermaus/retrofit2/LoganSquareConverterFactory.java
@@ -34,7 +34,7 @@ public final class LoganSquareConverterFactory extends Converter.Factory {
         if (isSupported(type)) {
             return new LoganSquareResponseBodyConverter(type);
         } else {
-            return null;
+            return super.responseBodyConverter(type, annotations, retrofit);
         }
     }
 
@@ -43,7 +43,7 @@ public final class LoganSquareConverterFactory extends Converter.Factory {
         if (isSupported(type)) {
             return new LoganSquareRequestBodyConverter(type);
         } else {
-            return null;
+            return super.requestBodyConverter(type, parameterAnnotations, methodAnnotations, retrofit);
         }
     }
 }


### PR DESCRIPTION
Fixed the issue of have multiple Converter Factory, LoganSquareConverterFactory can only be added at the end.